### PR TITLE
883.projection_area_of_3D_shapes.py

### DIFF
--- a/883.projection_area_of_3D_shapes.py
+++ b/883.projection_area_of_3D_shapes.py
@@ -1,0 +1,23 @@
+class Solution(object):
+    def projectionArea(self, grid):
+        """
+        :type grid: List[List[int]]
+        :rtype: int
+        """
+        import numpy as np
+        grid = np.array(grid)
+        if len(grid)==1:
+            max1=len(grid)
+        else:
+            non_zero = grid[np.where(grid!=0)]
+            max1 = len(non_zero)
+        raw1 = np.amax(grid, axis = 1)
+        raw2 = np.amax(grid, axis = 0)
+        max2 = np.sum(raw1)
+        max3 = np.sum(raw2)
+        return max1+max2+max3
+
+obj1 = Solution()
+print(obj1.projectionArea([[1,2],[3,4]]))
+print(obj1.projectionArea([[2]]))
+print(obj1.projectionArea([[1,0],[0,2]]))


### PR DESCRIPTION
You are given an n x n grid where we place some 1 x 1 x 1 cubes that are axis-aligned with the x, y, and z axes.

Each value v = grid[i][j] represents a tower of v cubes placed on top of the cell (i, j).

We view the projection of these cubes onto the xy, yz, and zx planes.

A projection is like a shadow, that maps our 3-dimensional figure to a 2-dimensional plane. We are viewing the "shadow" when looking at the cubes from the top, the front, and the side.

Return the total area of all three projections.

Example 1:
Input: grid = [[1,2],[3,4]]
Output: 17
Explanation: Here are the three projections ("shadows") of the shape made with each axis-aligned plane.

Example 2:
Input: grid = [[2]]
Output: 5

Example 3:
Input: grid = [[1,0],[0,2]]
Output: 8